### PR TITLE
Add basic Streamlit interface for pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,5 @@ pip install -r requirements.txt
 
 - Do **not** upload private or copyrighted research files.
 - The `data/` and `output/` folders are gitignored for privacy and size.
+## Web App
+Run `streamlit run webapp.py` to launch a simple interface for uploading documents and generating CSV outputs.

--- a/pipeline.py
+++ b/pipeline.py
@@ -1,0 +1,103 @@
+"""Pipeline utilities for the Kinesthetic Mind project."""
+
+import csv
+import json
+import uuid
+from pathlib import Path
+from typing import List, Dict
+
+# Basic text extraction utilities
+try:
+    from PyPDF2 import PdfReader
+except ImportError:  # Fallback if PyPDF2 missing during tests
+    PdfReader = None
+try:
+    import docx2txt
+except ImportError:
+    docx2txt = None
+
+class DeepDocument:
+    """Simple representation of a parsed document."""
+    def __init__(self, title: str, sections: List[Dict]):
+        self.title = title
+        self.sections = sections
+
+    def to_json(self) -> str:
+        return json.dumps({"title": self.title, "sections": self.sections}, indent=2)
+
+
+class DocumentPrepperAgent:
+    """Convert uploaded files into a Deep Document."""
+    def __init__(self, files: List[Dict]):
+        self.files = files
+
+    def _pdf_to_text(self, data: bytes) -> str:
+        if not PdfReader:
+            return ""
+        with open("tmp.pdf", "wb") as f:
+            f.write(data)
+        reader = PdfReader("tmp.pdf")
+        return "\n".join(page.extract_text() or "" for page in reader.pages)
+
+    def _docx_to_text(self, data: bytes) -> str:
+        if not docx2txt:
+            return ""
+        with open("tmp.docx", "wb") as f:
+            f.write(data)
+        return docx2txt.process("tmp.docx")
+
+    def _file_to_text(self, fileobj: Dict) -> str:
+        name = fileobj.get("name")
+        data = fileobj.get("data")
+        if name.endswith(".pdf"):
+            return self._pdf_to_text(data)
+        elif name.endswith(".docx"):
+            return self._docx_to_text(data)
+        else:
+            return data.decode("utf-8", errors="ignore")
+
+    def run(self) -> DeepDocument:
+        text = "\n".join(self._file_to_text(f) for f in self.files)
+        sections = [{"id": str(uuid.uuid4()), "title": "Document", "content": text}]
+        deep = DeepDocument(title="Deep Document", sections=sections)
+        Path("deep_document.json").write_text(deep.to_json())
+        return deep
+
+
+class DocumentParserAgent:
+    """Very lightweight entity and relation extractor."""
+
+    def __init__(self, deep_document: DeepDocument):
+        self.doc = deep_document
+
+    def extract_entities(self):
+        entities = []
+        for sec in self.doc.sections:
+            words = set(sec["content"].split())
+            for w in words:
+                if w.isalpha() and len(w) > 4:
+                    entities.append({"id": w.lower(), "name": w, "section_id": sec["id"]})
+        return entities
+
+    def extract_edges(self, entities):
+        # dummy edges between sequential entities
+        edges = []
+        for i in range(len(entities)-1):
+            src = entities[i]
+            tgt = entities[i+1]
+            edges.append({"source": src["id"], "target": tgt["id"], "section_id": src["section_id"]})
+        return edges
+
+    def run(self):
+        entities = self.extract_entities()
+        edges = self.extract_edges(entities)
+        with open("entities.csv", "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=entities[0].keys())
+            writer.writeheader(); writer.writerows(entities)
+        with open("edges.csv", "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=edges[0].keys())
+            writer.writeheader(); writer.writerows(edges)
+        return entities, edges
+
+
+__all__ = ["DeepDocument", "DocumentPrepperAgent", "DocumentParserAgent"]

--- a/requirements_Version2.txt
+++ b/requirements_Version2.txt
@@ -14,3 +14,4 @@ pydantic
 networkx
 
 # Add more as you build out your agents
+streamlit

--- a/webapp.py
+++ b/webapp.py
@@ -1,0 +1,36 @@
+"""Simple Streamlit app for the Kinesthetic Mind pipeline."""
+
+import io
+import streamlit as st
+from typing import Dict
+from pipeline import DocumentPrepperAgent, DocumentParserAgent
+
+st.title("Kinesthetic Mind Pipeline")
+
+st.sidebar.header("Upload Files")
+uploaded = st.sidebar.file_uploader("Add research PDFs or docs", accept_multiple_files=True)
+
+if uploaded:
+    files = []
+    for f in uploaded:
+        files.append({"name": f.name, "data": f.read()})
+    if st.sidebar.button("Process"):
+        st.info("Running Document Prepper...")
+        prepper = DocumentPrepperAgent(files)
+        deep_doc = prepper.run()
+        st.success("Deep Document created")
+
+        st.info("Parsing Document...")
+        parser = DocumentParserAgent(deep_doc)
+        entities, edges = parser.run()
+        st.success(f"Found {len(entities)} entities and {len(edges)} edges")
+
+        with open("entities.csv") as f:
+            st.download_button("Download entities.csv", f.read(), file_name="entities.csv")
+        with open("edges.csv") as f:
+            st.download_button("Download edges.csv", f.read(), file_name="edges.csv")
+
+        st.header("Quick Graph Preview")
+        st.json({"entities": entities[:5], "edges": edges[:5]})
+else:
+    st.write("Upload files to begin.")


### PR DESCRIPTION
## Summary
- implement simplified pipeline utilities in `pipeline.py`
- add Streamlit web app `webapp.py`
- document app usage in README
- include `streamlit` in requirements

## Testing
- `python -m py_compile pipeline.py webapp.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885368e73ac832192aa082c2ec00f7d